### PR TITLE
Integrate promotional banners in search page and improve admin filters

### DIFF
--- a/noticed_v2/app/admin/promo_banners.rb
+++ b/noticed_v2/app/admin/promo_banners.rb
@@ -26,9 +26,11 @@ ActiveAdmin.register PromoBanner do
   end
 
   filter :title
-  filter :position, as: :select, collection: [['Barra Lateral', 'sidebar'], ['Cabeçalho', 'header'], ['Rodapé', 'footer']]
+  filter :position, as: :select, collection: -> { PromoBanner.distinct.pluck(:position).map { |pos| [PromoBanner.new(position: pos).position_label, pos] } }
   filter :active
+  filter :priority
   filter :created_at
+  filter :updated_at
 
   form do |f|
     f.semantic_errors

--- a/noticed_v2/app/admin/promotional_banners.rb
+++ b/noticed_v2/app/admin/promotional_banners.rb
@@ -54,10 +54,12 @@ ActiveAdmin.register PromotionalBanner do
 
   # Filtros
   filter :title
-  filter :provider, as: :select, collection: -> { Provider.all.pluck(:name, :id) }
-  filter :position, as: :select, collection: PromotionalBanner.positions.map { |k, v| [k.humanize, k] }
+  filter :provider, as: :select, collection: -> { Provider.order(:name).pluck(:name, :id) }
+  filter :position, as: :select, collection: PromotionalBanner.positions.keys.map { |k| [k.humanize, k] }
   filter :active
+  filter :display_order
   filter :created_at
+  filter :updated_at
   filter :start_date
   filter :end_date
 

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -3,6 +3,7 @@ import { useSearchParams, Link, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import AdvancedSearch from '../components/search/AdvancedSearch';
 import PromoBannerSidebar from '../components/banners/PromoBannerSidebar';
+import BannerSlider from '../components/BannerSlider';
 import { Card, CardContent } from '../components/ui/card';
 import { Badge } from '../components/ui/badge';
 import { Button } from '../components/ui/button';
@@ -401,6 +402,7 @@ const SearchPage: React.FC = () => {
           {/* Banner lateral direito */}
           <aside className="lg:col-span-3">
             <div className="space-y-6">
+              <BannerSlider position="search_results" showCloseButton={false} />
               <PromoBannerSidebar />
             </div>
           </aside>


### PR DESCRIPTION
## Summary
- display promotional banners on advanced search with BannerSlider
- enhance ActiveAdmin filters for promo and promotional banners

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 123 problems (106 errors, 17 warnings))*
- `cd noticed_v2 && bundle exec rspec` *(fails: bundler: command not found: rspec; Your Ruby version is 3.4.4, but your Gemfile specified 3.2.2)*

------
https://chatgpt.com/codex/tasks/task_e_68b756d9c0f48326822d02889d5ec582