### PR TITLE
feat: update promotional banners fetch

### DIFF
--- a/src/hooks/usePromoBanners.ts
+++ b/src/hooks/usePromoBanners.ts
@@ -32,9 +32,9 @@ export const usePromoBanners = (position?: string) => {
       try {
         setLoading(true);
         const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000/api/v1';
-        const url = position 
-          ? `${apiUrl}/promo_banners?position=${position}`
-          : `${apiUrl}/promo_banners`;
+        const url = position
+          ? `${apiUrl}/promotional_banners/by_position/${position}`
+          : `${apiUrl}/promotional_banners`;
         
         console.log('Fetching banners from:', url);
         
@@ -46,7 +46,7 @@ export const usePromoBanners = (position?: string) => {
         
         const data = await response.json();
         console.log('Banners received:', data);
-        setBanners(data);
+        setBanners(data.data);
       } catch (err) {
         console.error('Error fetching banners:', err);
         if (retries > 0) {
@@ -72,3 +72,4 @@ export const usePromoBanners = (position?: string) => {
     getBannerByPosition
   };
 };
+


### PR DESCRIPTION
## Summary
- fetch promotional banners using new `promotional_banners` endpoints
- parse API response to use returned `data` array

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars and other lint errors)*
- `npm run build` *(fails: TypeScript errors and missing modules)*
- `npm run dev` *(fails: unresolved dependency @radix-ui/react-avatar)*


------
https://chatgpt.com/codex/tasks/task_e_68b75f8978608326b41b702153fe6689