### PR TITLE
Handle missing banner API with mock fallback

### DIFF
--- a/src/hooks/usePromoBanners.ts
+++ b/src/hooks/usePromoBanners.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import BannerService from '@/services/bannerService';
 
 export interface PromoBanner {
   id: number;
@@ -28,33 +29,75 @@ export const usePromoBanners = (position?: string) => {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const fetchBanners = async (retries = 3, delay = 1000) => {
-      try {
-        setLoading(true);
-        const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000/api/v1';
-        const url = position
+    const fetchBanners = async () => {
+      setLoading(true);
+      const apiUrl = import.meta.env.VITE_API_URL;
+
+      const url = apiUrl
+        ? position
           ? `${apiUrl}/promotional_banners/by_position/${position}`
-          : `${apiUrl}/promotional_banners`;
-        
-        console.log('Fetching banners from:', url);
-        
+          : `${apiUrl}/promotional_banners`
+        : '';
+
+      try {
+        if (!apiUrl) {
+          throw new Error('VITE_API_URL não configurada');
+        }
+
         const response = await fetch(url);
-        
+
         if (!response.ok) {
           throw new Error('Falha ao carregar banners');
         }
-        
+
         const data = await response.json();
-        console.log('Banners received:', data);
         setBanners(data.data);
       } catch (err) {
         console.error('Error fetching banners:', err);
-        if (retries > 0) {
-          setTimeout(() => fetchBanners(retries - 1, delay * 2), delay + Math.random() * 1000);
-        } else {
-          setError(err instanceof Error ? err.message : 'Erro desconhecido');
-          setLoading(false);
+        try {
+          const mock = await BannerService.getAllBanners();
+          const mapped: PromoBanner[] = mock.map((b, index) => ({
+            id: Number(b.id) || index,
+            title: b.title,
+            subtitle: b.description,
+            button_text: b.ctaText,
+            button_url: b.ctaLink,
+            background_color: b.backgroundColor,
+            text_color: b.textColor,
+            position: b.position === 'top' ? 'header' : b.position === 'center' ? 'sidebar' : 'footer',
+            priority: b.isPremium ? 1 : 0,
+            background_image_url: b.companyLogo,
+            show_title: true,
+            show_subtitle: !!b.description,
+            overlay_enabled: false,
+            overlay_color: '#000000',
+            overlay_opacity: 0.5,
+            text_align: 'left'
+          }));
+          setBanners(mapped);
+          setError('Exibindo banners mockados');
+        } catch (mockErr) {
+          console.error('Error loading mock banners:', mockErr);
+          setBanners([
+            {
+              id: 0,
+              title: 'Confira nossas ofertas',
+              background_color: '#f3f3f3',
+              text_color: '#333333',
+              position: position === 'header' || position === 'footer' ? position : 'sidebar',
+              priority: 0,
+              show_title: true,
+              show_subtitle: false,
+              overlay_enabled: false,
+              overlay_color: '#000000',
+              overlay_opacity: 0.5,
+              text_align: 'left'
+            }
+          ]);
+          setError('Não foi possível carregar os banners. Exibindo banner padrão.');
         }
+      } finally {
+        setLoading(false);
       }
     };
 


### PR DESCRIPTION
## Summary
- handle undefined `VITE_API_URL` and map banners from mock service
- default to mock or placeholder banners when API calls fail

## Testing
- `npm run lint` *(fails: Failed to load plugin '@typescript-eslint')*
- `npm run build` *(fails: multiple TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b767ad4bfc8326bf1ac18ac6805ff2