### PR TITLE
Fix provider category filtering and abort cleanup

### DIFF
--- a/src/components/layout/EnhancedHeader.tsx
+++ b/src/components/layout/EnhancedHeader.tsx
@@ -139,9 +139,12 @@ const EnhancedHeader: React.FC = () => {
 
     return () => {
       cancelled = true;
-      // Only abort if the controller is not already aborted
-      if (controller.signal && !controller.signal.aborted) {
-        controller.abort();
+      try {
+        if (controller.signal && !controller.signal.aborted) {
+          controller.abort();
+        }
+      } catch (e) {
+        console.debug('Abort controller cleanup failed', e);
       }
     };
   }, []);

--- a/src/pages/CategoriesPage.tsx
+++ b/src/pages/CategoriesPage.tsx
@@ -222,7 +222,13 @@ function CategoriesPage() {
 
     return () => {
       cancelled = true;
-      controller.abort();
+      try {
+        if (!controller.signal.aborted) {
+          controller.abort();
+        }
+      } catch (e) {
+        console.debug('Abort controller cleanup failed', e);
+      }
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- handle fetch aborts safely in header, categories, and category pages
- pass search filters to provider queries so providers show only in selected categories
- guard provider tag helpers in Rails API to avoid 422 errors when tags are missing

## Testing
- `npm run lint` (fails: 154 problems)
- `bundle exec rspec` (fails: bundler command not found)
- `bundle exec rake test` (fails: Ruby version mismatch)


------
https://chatgpt.com/codex/tasks/task_e_68bbb22d0a908326bfd905b3d3fac183