### PR TITLE
Handle aborted fetches and sequential category loading

### DIFF
--- a/src/components/layout/EnhancedHeader.tsx
+++ b/src/components/layout/EnhancedHeader.tsx
@@ -96,12 +96,11 @@ const EnhancedHeader: React.FC = () => {
   const [categories, setCategories] = useState<Category[]>([]);
 
   useEffect(() => {
-    const controller = new AbortController();
     let cancelled = false;
 
     const run = async () => {
       try {
-        const result = await apiService.getCategories(controller.signal);
+        const result = await apiService.getCategories();
 
         // Check if the component is still mounted
         if (cancelled) return;
@@ -139,13 +138,6 @@ const EnhancedHeader: React.FC = () => {
 
     return () => {
       cancelled = true;
-      try {
-        if (controller.signal && !controller.signal.aborted) {
-          controller.abort();
-        }
-      } catch (e) {
-        console.debug('Abort controller cleanup failed', e);
-      }
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- remove abort controller cleanup that caused AbortError warnings
- fetch category data before providers and stop early when missing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb5196e04832684fd644fadac7a70