### PR TITLE
Clean up API base controller by dropping doorkeeper hooks

### DIFF
--- a/noticed_v2/app/controllers/api/v1/base_controller.rb
+++ b/noticed_v2/app/controllers/api/v1/base_controller.rb
@@ -1,29 +1,16 @@
 class Api::V1::BaseController < ApplicationController
   protect_from_forgery with: :null_session
-  before_action :doorkeeper_authorize!, if: :doorkeeper_installed?
-  
+
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
   rescue_from ActiveRecord::RecordInvalid, with: :unprocessable_entity
   rescue_from StandardError, with: :internal_server_error
-  
+
   private
-  
-  def current_user
-    if doorkeeper_installed?
-      @current_user ||= User.find(doorkeeper_token.resource_owner_id) if doorkeeper_token
-    else
-      super
-    end
-  end
-  
-  def doorkeeper_installed?
-    defined?(Doorkeeper)
-  end
-  
+
   def not_found(exception)
     render json: { errors: [{ status: '404', title: 'Not Found', detail: exception.message }] }, status: :not_found
   end
-  
+
   def unprocessable_entity(exception)
     render json: { errors: [{ status: '422', title: 'Unprocessable Entity', detail: exception.message }] }, status: :unprocessable_entity
   end
@@ -33,3 +20,4 @@ class Api::V1::BaseController < ApplicationController
     render json: { errors: [{ status: '500', title: 'Internal Server Error', detail: 'An unexpected error occurred.' }] }, status: :internal_server_error
   end
 end
+


### PR DESCRIPTION
## Summary
- remove doorkeeper authorization hooks from API base controller
- streamline API error handling without OAuth checks

## Testing
- `bundle install` *(fails: Your Ruby version is 3.4.4, but your Gemfile specified 3.2.2)*
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc0b19c3c832694e8221f0bb1b70a