### PR TITLE
Add user validation and unique indexes

### DIFF
--- a/noticed_v2/app/models/user.rb
+++ b/noticed_v2/app/models/user.rb
@@ -6,6 +6,9 @@ class User < ApplicationRecord
 
   after_create :set_default_approved
 
+  validates :email, presence: true, uniqueness: true
+  validates :name, presence: true
+
   def active_for_authentication?
     super && approved?
   end

--- a/noticed_v2/db/migrate/20250906050500_add_unique_indexes_to_users.rb
+++ b/noticed_v2/db/migrate/20250906050500_add_unique_indexes_to_users.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexesToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_index :users, :email, unique: true unless index_exists?(:users, :email, unique: true)
+    add_index :users, [:uid, :provider], unique: true unless index_exists?(:users, [:uid, :provider], unique: true)
+  end
+end

--- a/noticed_v2/spec/models/user_spec.rb
+++ b/noticed_v2/spec/models/user_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  it 'is invalid without an email' do
+    user = User.new(name: 'Test User', password: 'password')
+    expect(user).not_to be_valid
+    expect(user.errors[:email]).to include("can't be blank")
+  end
+
+  it 'is invalid without a name' do
+    user = User.new(email: 'test@example.com', password: 'password')
+    expect(user).not_to be_valid
+    expect(user.errors[:name]).to include("can't be blank")
+  end
+
+  it 'validates uniqueness of email' do
+    User.create!(email: 'unique@example.com', name: 'Existing', password: 'password')
+    user = User.new(email: 'unique@example.com', name: 'Another', password: 'password')
+    expect(user).not_to be_valid
+    expect(user.errors[:email]).to include('has already been taken')
+  end
+end


### PR DESCRIPTION
## Summary
- add presence and uniqueness validation for user email
- require name for users
- ensure unique database indexes for email and auth identifiers
- cover new validations with model specs

## Testing
- `bundle exec rspec spec/models/user_spec.rb` *(fails: bundler could not find rspec; `bundle install` failed with 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc0b2e26c8326976b18fc1e5db6f3