### PR TITLE
Use env var for CORS origin

### DIFF
--- a/noticed_v2/.env.example
+++ b/noticed_v2/.env.example
@@ -1,0 +1,3 @@
+# Environment variable examples
+# Allowed frontend origin for CORS
+FRONTEND_ORIGIN=http://localhost:5173

--- a/noticed_v2/config/initializers/cors.rb
+++ b/noticed_v2/config/initializers/cors.rb
@@ -2,7 +2,7 @@
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     # O domínio do seu frontend
-    origins 'http://localhost:5173'
+    origins ENV.fetch('FRONTEND_ORIGIN', 'http://localhost:5173')
 
     resource '*',
       headers: :any,


### PR DESCRIPTION
## Summary
- allow configuring CORS origin via `FRONTEND_ORIGIN`
- document `FRONTEND_ORIGIN` in `.env.example`

## Testing
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*
- `bundle install` *(fails: Your Ruby version is 3.4.4, but your Gemfile specified 3.2.2)*
- `FRONTEND_ORIGIN="https://example.com" bin/rails runner -e production 'puts ENV.fetch("FRONTEND_ORIGIN")'` *(fails: Your Ruby version is 3.4.4, but your Gemfile specified 3.2.2)*
- `FRONTEND_ORIGIN="https://example.com" bin/rails runner -e staging 'puts ENV.fetch("FRONTEND_ORIGIN")'` *(fails: Your Ruby version is 3.4.4, but your Gemfile specified 3.2.2)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc0b445d88326ad67ae0a97aa2c1f