### PR TITLE
Add serializers and update API controllers

### DIFF
--- a/noticed_v2/app/controllers/api/v1/promo_banners_controller.rb
+++ b/noticed_v2/app/controllers/api/v1/promo_banners_controller.rb
@@ -9,19 +9,19 @@ class Api::V1::PromoBannersController < ApplicationController
     # Filter by position if specified
     @promo_banners = @promo_banners.by_position(params[:position]) if params[:position].present?
     
-    render json: @promo_banners.map { |banner| banner_json(banner) }
+    render json: @promo_banners, each_serializer: Api::V1::PromoBannerSerializer
   end
 
   # GET /api/v1/promo_banners/:id
   def show
-    render json: banner_json(@promo_banner)
+    render json: @promo_banner, serializer: Api::V1::PromoBannerSerializer
   end
 
   # GET /api/v1/promo_banners/sidebar
   def sidebar
     @banner = PromoBanner.sidebar_banner
     if @banner
-      render json: banner_json(@banner)
+      render json: @banner, serializer: Api::V1::PromoBannerSerializer
     else
       render json: { error: 'No sidebar banner found' }, status: :not_found
     end
@@ -35,28 +35,4 @@ class Api::V1::PromoBannersController < ApplicationController
     render json: { error: 'Banner not found' }, status: :not_found
   end
 
-  def banner_json(banner)
-    {
-      id: banner.id,
-      title: banner.title,
-      subtitle: banner.subtitle,
-      button_text: banner.button_text,
-      button_url: banner.button_url,
-      button_secondary_text: banner.button_secondary_text,
-      button_secondary_url: banner.button_secondary_url,
-      background_color: banner.background_color,
-      text_color: banner.text_color,
-      position: banner.position,
-      priority: banner.priority,
-      background_image_url: banner.background_image_url,
-      show_title: banner.show_title,
-      show_subtitle: banner.show_subtitle,
-      overlay_enabled: banner.overlay_enabled,
-      overlay_color: banner.overlay_color,
-      overlay_opacity: banner.overlay_opacity,
-      text_align: banner.text_align,
-      created_at: banner.created_at,
-      updated_at: banner.updated_at
-    }
-  end
 end

--- a/noticed_v2/app/controllers/api/v1/reviews_controller.rb
+++ b/noticed_v2/app/controllers/api/v1/reviews_controller.rb
@@ -15,12 +15,12 @@ class Api::V1::ReviewsController < Api::V1::BaseController
     
     @reviews = @reviews.order(featured: :desc, created_at: :desc)
     
-    render json: @reviews, include: [:solution, :user]
+    render json: @reviews, each_serializer: Api::V1::ReviewSerializer
   end
   
   # GET /api/v1/reviews/:id
   def show
-    render json: @review, include: [:solution, :user]
+    render json: @review, serializer: Api::V1::ReviewSerializer
   end
   
   # POST /api/v1/reviews
@@ -29,7 +29,7 @@ class Api::V1::ReviewsController < Api::V1::BaseController
     @review.status = :pending # Ensure status is pending on creation
     
     if @review.save
-      render json: @review, status: :created, include: [:solution, :user]
+      render json: @review, serializer: Api::V1::ReviewSerializer, status: :created
     else
       render json: { errors: @review.errors }, status: :unprocessable_entity
     end
@@ -38,7 +38,7 @@ class Api::V1::ReviewsController < Api::V1::BaseController
   # PUT/PATCH /api/v1/reviews/:id
   def update
     if @review.update(review_params)
-      render json: @review, include: [:solution, :user]
+      render json: @review, serializer: Api::V1::ReviewSerializer
     else
       render json: { errors: @review.errors }, status: :unprocessable_entity
     end

--- a/noticed_v2/app/serializers/api/v1/promo_banner_serializer.rb
+++ b/noticed_v2/app/serializers/api/v1/promo_banner_serializer.rb
@@ -1,0 +1,8 @@
+class Api::V1::PromoBannerSerializer < ActiveModel::Serializer
+  attributes :id, :title, :subtitle, :button_text, :button_url,
+             :button_secondary_text, :button_secondary_url,
+             :background_color, :text_color, :position, :priority,
+             :background_image_url, :show_title, :show_subtitle,
+             :overlay_enabled, :overlay_color, :overlay_opacity,
+             :text_align, :created_at, :updated_at
+end

--- a/noticed_v2/app/serializers/api/v1/provider_serializer.rb
+++ b/noticed_v2/app/serializers/api/v1/provider_serializer.rb
@@ -1,0 +1,53 @@
+class Api::V1::ProviderSerializer < ActiveModel::Serializer
+  include Rails.application.routes.url_helpers
+
+  attributes :id, :name, :slug, :short_description, :description,
+             :country, :address, :phone, :foundation_year, :members_count,
+             :status, :premium, :premium_effect_active, :tags, :social_links,
+             :logo_url, :cover_image_url, :banner_image_url,
+             :rating, :review_count, :installed_capacity_mw,
+             :location, :specialties
+
+  has_many :categories, serializer: Api::V1::CategorySerializer
+
+  def premium
+    object.premium?
+  end
+
+  def logo_url
+    rails_blob_url(object.logo, only_path: false) if object.logo.attached?
+  end
+
+  def cover_image_url
+    rails_blob_url(object.cover_image, only_path: false) if object.cover_image.attached?
+  end
+
+  def banner_image_url
+    rails_blob_url(object.banner_image, only_path: false) if object.banner_image.attached?
+  end
+
+  def rating
+    object.overall_average_rating
+  end
+
+  def review_count
+    object.overall_reviews_count
+  end
+
+  def installed_capacity_mw
+    capacity_tag = object.tags&.find { |tag| tag.start_with?("capacity:") }
+    return 0 unless capacity_tag
+    capacity_tag.gsub('capacity:', '').gsub('MW', '').to_f
+  end
+
+  def location
+    location_tag = object.tags&.find { |tag| tag.start_with?("location:") }
+    return "" unless location_tag
+    location_tag.gsub('location:', '')
+  end
+
+  def specialties
+    system_prefixes = ['employees:', 'location:', 'email:', 'website:', 'experience:', 'projects:', 'capacity:']
+    (object.tags || []).reject { |tag| system_prefixes.any? { |prefix| tag.start_with?(prefix) } }
+  end
+end

--- a/noticed_v2/app/serializers/api/v1/review_serializer.rb
+++ b/noticed_v2/app/serializers/api/v1/review_serializer.rb
@@ -1,0 +1,7 @@
+class Api::V1::ReviewSerializer < ActiveModel::Serializer
+  attributes :id, :rating, :title, :comment, :status,
+             :solution_id, :user_id, :created_at, :updated_at
+
+  belongs_to :solution, if: -> { object.solution.present? }
+  belongs_to :user
+end

--- a/noticed_v2/spec/serializers/promo_banner_serializer_spec.rb
+++ b/noticed_v2/spec/serializers/promo_banner_serializer_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::PromoBannerSerializer do
+  describe '#as_json' do
+    it 'serializes promo banner attributes' do
+      banner = PromoBanner.create!(
+        title: 'Promo',
+        position: 'header',
+        background_color: '#000000',
+        text_color: '#ffffff',
+        priority: 1
+      )
+
+      json = described_class.new(banner).as_json
+
+      expect(json[:title]).to eq('Promo')
+      expect(json[:position]).to eq('header')
+    end
+  end
+end

--- a/noticed_v2/spec/serializers/provider_serializer_spec.rb
+++ b/noticed_v2/spec/serializers/provider_serializer_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::ProviderSerializer do
+  describe '#as_json' do
+    it 'serializes provider attributes' do
+      provider = Provider.create!(
+        name: 'Test Co',
+        country: 'BR',
+        foundation_year: 2020,
+        members_count: 5,
+        status: 'active',
+        city: 'Sao Paulo',
+        state: 'SP'
+      )
+
+      json = described_class.new(provider).as_json
+
+      expect(json[:id]).to eq(provider.id)
+      expect(json[:name]).to eq('Test Co')
+      expect(json[:status]).to eq('active')
+    end
+  end
+end

--- a/noticed_v2/spec/serializers/review_serializer_spec.rb
+++ b/noticed_v2/spec/serializers/review_serializer_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::ReviewSerializer do
+  describe '#as_json' do
+    it 'serializes review attributes' do
+      user = User.create!(email: 'user@example.com', password: 'password')
+      review = Review.create!(user: user, rating: 4, title: 'Good', comment: 'Nice', status: 'approved')
+
+      json = described_class.new(review).as_json
+
+      expect(json[:rating]).to eq(4)
+      expect(json[:title]).to eq('Good')
+      expect(json[:user_id]).to eq(user.id)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add Provider, PromoBanner, and Review serializers for API v1
- render controllers with their serializers instead of manual JSON
- test serializers for essential fields

## Testing
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc0b54bb88326b413308ffc4353fc