### PR TITLE
Configure Sidekiq for background notifications

### DIFF
--- a/noticed_v2/app/models/comment.rb
+++ b/noticed_v2/app/models/comment.rb
@@ -19,11 +19,8 @@ class Comment < ApplicationRecord
   private
 
   def notify_recipient
-    CommentNotifier.with(record: self, post:).deliver_later(post.user)
-    # Using deliver_later will execute a background job when you hit 'post' for your comment.
-    # This means that it won't stall the interface while the job is being processed.
-    # You can simply post your comment and continue with your tasks, while in the background,
-    # the Rails system takes care of delivering the comment in the background.
+    CommentNotificationWorker.perform_async(id)
+    # The worker will handle delivering the notification asynchronously
   end
 
   def cleanup_notifications

--- a/noticed_v2/app/workers/comment_notification_worker.rb
+++ b/noticed_v2/app/workers/comment_notification_worker.rb
@@ -1,0 +1,9 @@
+class CommentNotificationWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :notifications
+
+  def perform(comment_id)
+    comment = Comment.find(comment_id)
+    CommentNotifier.with(record: comment, post: comment.post).deliver(comment.post.user)
+  end
+end

--- a/noticed_v2/config/application.rb
+++ b/noticed_v2/config/application.rb
@@ -25,8 +25,11 @@ module ReviewsCore
     
     # Load custom locale files
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
-    
+
     # ActiveAdmin configuration
     config.active_record.default_timezone = :local
+
+    # Background job queue adapter
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/noticed_v2/config/initializers/sidekiq.rb
+++ b/noticed_v2/config/initializers/sidekiq.rb
@@ -1,0 +1,7 @@
+Sidekiq.configure_server do |config|
+  config.redis = { url: ENV.fetch('REDIS_URL', 'redis://localhost:6379/0') }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: ENV.fetch('REDIS_URL', 'redis://localhost:6379/0') }
+end

--- a/noticed_v2/config/sidekiq.yml
+++ b/noticed_v2/config/sidekiq.yml
@@ -1,0 +1,5 @@
+:concurrency: 5
+:queues:
+  - default
+  - mailers
+  - notifications

--- a/noticed_v2/start_server.sh
+++ b/noticed_v2/start_server.sh
@@ -5,6 +5,7 @@ echo "Iniciando servidor Rails..."
 
 # Mata processos Rails existentes
 pkill -f "rails server" 2>/dev/null || true
+pkill -f "sidekiq" 2>/dev/null || true
 
 # Verifica se há migrações pendentes
 echo "Verificando migrações..."
@@ -12,6 +13,10 @@ rails db:migrate:status | grep "down" && {
     echo "Executando migrações pendentes..."
     rails db:migrate
 }
+
+# Inicia o Sidekiq
+echo "Iniciando Sidekiq..."
+bundle exec sidekiq -C config/sidekiq.yml &
 
 # Inicia o servidor
 echo "Iniciando servidor na porta 3000..."


### PR DESCRIPTION
## Summary
- add Sidekiq configuration and initializer
- set ActiveJob adapter to Sidekiq
- create notification worker and update comment model
- launch Sidekiq from start script

## Testing
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc0b6f2608326952fb7d8bca4c7bf