### PR TITLE
Add Pundit policies for banner and provider management

### DIFF
--- a/noticed_v2/app/controllers/application_controller.rb
+++ b/noticed_v2/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  include Pundit::Authorization
+
   before_action :set_notifications, if: :current_user
 
   private

--- a/noticed_v2/app/policies/application_policy.rb
+++ b/noticed_v2/app/policies/application_policy.rb
@@ -1,0 +1,57 @@
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    scope.where(id: record.id).exists?
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  def admin?
+    user.is_a?(AdminUser)
+  end
+
+  def scope
+    Pundit.policy_scope!(user, record.class)
+  end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/noticed_v2/app/policies/banner_policy.rb
+++ b/noticed_v2/app/policies/banner_policy.rb
@@ -1,0 +1,27 @@
+class BannerPolicy < ApplicationPolicy
+  def index?
+    admin?
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    admin?
+  end
+
+  def update?
+    admin?
+  end
+
+  def destroy?
+    admin?
+  end
+
+  class Scope < Scope
+    def resolve
+      admin? ? scope.all : scope.none
+    end
+  end
+end

--- a/noticed_v2/app/policies/provider_policy.rb
+++ b/noticed_v2/app/policies/provider_policy.rb
@@ -1,0 +1,27 @@
+class ProviderPolicy < ApplicationPolicy
+  def index?
+    admin?
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    admin?
+  end
+
+  def update?
+    admin?
+  end
+
+  def destroy?
+    admin?
+  end
+
+  class Scope < Scope
+    def resolve
+      admin? ? scope.all : scope.none
+    end
+  end
+end

--- a/noticed_v2/spec/policies/banner_policy_spec.rb
+++ b/noticed_v2/spec/policies/banner_policy_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe BannerPolicy, type: :policy do
+  let(:record) { Banner.new }
+
+  context 'when user is an admin' do
+    let(:user) { AdminUser.new }
+    subject(:policy) { described_class.new(user, record) }
+
+    it 'permits management actions' do
+      expect(policy.index?).to be true
+      expect(policy.show?).to be true
+      expect(policy.create?).to be true
+      expect(policy.update?).to be true
+      expect(policy.destroy?).to be true
+    end
+  end
+
+  context 'when user is a regular user' do
+    let(:user) { User.new }
+    subject(:policy) { described_class.new(user, record) }
+
+    it 'denies management actions' do
+      expect(policy.index?).to be false
+      expect(policy.create?).to be false
+      expect(policy.update?).to be false
+      expect(policy.destroy?).to be false
+    end
+  end
+end

--- a/noticed_v2/spec/policies/provider_policy_spec.rb
+++ b/noticed_v2/spec/policies/provider_policy_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe ProviderPolicy, type: :policy do
+  let(:record) { Provider.new }
+
+  context 'when user is an admin' do
+    let(:user) { AdminUser.new }
+    subject(:policy) { described_class.new(user, record) }
+
+    it 'permits management actions' do
+      expect(policy.index?).to be true
+      expect(policy.show?).to be true
+      expect(policy.create?).to be true
+      expect(policy.update?).to be true
+      expect(policy.destroy?).to be true
+    end
+  end
+
+  context 'when user is a regular user' do
+    let(:user) { User.new }
+    subject(:policy) { described_class.new(user, record) }
+
+    it 'denies management actions' do
+      expect(policy.index?).to be false
+      expect(policy.create?).to be false
+      expect(policy.update?).to be false
+      expect(policy.destroy?).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- include Pundit in ApplicationController
- add policies for Banner and Provider
- cover policies with basic RSpec tests

## Testing
- `bundle exec rspec spec/policies` *(fails: command not found; run `bundle install`)*
- `bundle install` *(fails: Ruby version 3.4.4 not supported; Gemfile requires 3.2.2)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc0b7e9e4832698a51dc1b481eb06