### PR TITLE
Add request specs and model validation tests

### DIFF
--- a/noticed_v2/spec/models/category_spec.rb
+++ b/noticed_v2/spec/models/category_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe Category, type: :model do
+  it 'is invalid without a name' do
+    category = Category.new
+    expect(category).not_to be_valid
+    expect(category.errors[:name]).to include("can't be blank")
+  end
+
+  it 'limits promotional_text to 160 characters' do
+    text = 'a' * 161
+    category = Category.new(name: 'Energy', promotional_text: text)
+    expect(category).not_to be_valid
+    expect(category.errors[:promotional_text]).to be_present
+  end
+end

--- a/noticed_v2/spec/models/provider_spec.rb
+++ b/noticed_v2/spec/models/provider_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe Provider, type: :model do
+  before do
+    allow_any_instance_of(Provider).to receive(:notify_admins_of_new_provider)
+  end
+
+  it 'is invalid without a name' do
+    provider = Provider.new
+    expect(provider).not_to be_valid
+    expect(provider.errors[:name]).to include("can't be blank")
+  end
+
+  it 'validates state format' do
+    provider = Provider.new(
+      name: 'Test',
+      country: 'BR',
+      foundation_year: 2020,
+      members_count: 1,
+      status: 'active',
+      city: 'City',
+      state: 'Invalid',
+      tags: []
+    )
+    expect(provider).not_to be_valid
+    expect(provider.errors[:state]).to be_present
+  end
+end

--- a/noticed_v2/spec/models/user_spec.rb
+++ b/noticed_v2/spec/models/user_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  it 'is invalid without an email' do
+    user = User.new(password: 'password123')
+    expect(user).not_to be_valid
+    expect(user.errors[:email]).to include("can't be blank")
+  end
+
+  it 'sets approved to false by default' do
+    user = User.create!(email: 'new@example.com', password: 'password123')
+    expect(user.approved).to be_falsey
+  end
+end

--- a/noticed_v2/spec/requests/api/v1/auth_spec.rb
+++ b/noticed_v2/spec/requests/api/v1/auth_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe 'Authentication API', type: :request do
+  describe 'POST /api/v1/auth' do
+    it 'registers a new user' do
+      params = {
+        name: 'Test User',
+        email: 'test@example.com',
+        password: 'password123',
+        password_confirmation: 'password123'
+      }
+
+      post '/api/v1/auth', params: params
+
+      expect(response).to have_http_status(:success)
+      json = JSON.parse(response.body)
+      expect(json['status']).to eq('success')
+      expect(json.dig('data', 'email')).to eq('test@example.com')
+    end
+  end
+
+  describe 'POST /api/v1/auth/sign_in' do
+    let!(:user) do
+      u = User.create!(email: 'login@example.com', password: 'password123')
+      u.update(approved: true)
+      u
+    end
+
+    it 'logs in an approved user with valid credentials' do
+      post '/api/v1/auth/sign_in', params: { email: user.email, password: 'password123' }
+
+      expect(response).to have_http_status(:success)
+      json = JSON.parse(response.body)
+      expect(json['status']).to eq('success')
+      expect(json.dig('data', 'email')).to eq(user.email)
+    end
+
+    it 'rejects invalid credentials' do
+      post '/api/v1/auth/sign_in', params: { email: user.email, password: 'wrong' }
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end

--- a/noticed_v2/spec/requests/api/v1/categories_spec.rb
+++ b/noticed_v2/spec/requests/api/v1/categories_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe 'Categories API', type: :request do
+  describe 'GET /api/v1/categories' do
+    it 'returns active root categories' do
+      Category.create!(name: 'Solar', active: true)
+
+      get '/api/v1/categories'
+
+      expect(response).to have_http_status(:success)
+      json = JSON.parse(response.body)
+      expect(json.first['name']).to eq('Solar')
+    end
+  end
+
+  describe 'GET /api/v1/categories/:id' do
+    it 'returns the requested category' do
+      category = Category.create!(name: 'Energy', active: true)
+
+      get "/api/v1/categories/#{category.id}"
+
+      expect(response).to have_http_status(:success)
+      json = JSON.parse(response.body)
+      expect(json['id']).to eq(category.id)
+    end
+  end
+end

--- a/noticed_v2/spec/requests/api/v1/promotional_banners_spec.rb
+++ b/noticed_v2/spec/requests/api/v1/promotional_banners_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe 'Promotional Banners API', type: :request do
+  let(:valid_attributes) do
+    {
+      title: 'Promo',
+      background_color: '#FFFFFF',
+      text_color: '#000000',
+      link_url: 'http://example.com',
+      display_order: 1,
+      active: true
+    }
+  end
+
+  describe 'GET /api/v1/promotional_banners' do
+    it 'returns banners' do
+      PromotionalBanner.create!(valid_attributes)
+
+      get '/api/v1/promotional_banners'
+
+      expect(response).to have_http_status(:success)
+      json = JSON.parse(response.body)
+      expect(json['data'].first['title']).to eq('Promo')
+    end
+  end
+
+  describe 'GET /api/v1/promotional_banners/:id' do
+    it 'returns a banner' do
+      banner = PromotionalBanner.create!(valid_attributes)
+
+      get "/api/v1/promotional_banners/#{banner.id}"
+
+      expect(response).to have_http_status(:success)
+      json = JSON.parse(response.body)
+      expect(json['data']['id']).to eq(banner.id)
+    end
+  end
+end

--- a/noticed_v2/spec/requests/api/v1/providers_spec.rb
+++ b/noticed_v2/spec/requests/api/v1/providers_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe 'Providers API', type: :request do
+  before do
+    allow_any_instance_of(Provider).to receive(:notify_admins_of_new_provider)
+  end
+
+  let(:valid_attributes) do
+    {
+      name: 'Provider One',
+      country: 'BR',
+      foundation_year: 2020,
+      members_count: 5,
+      status: 'active',
+      city: 'City',
+      state: 'SP',
+      tags: []
+    }
+  end
+
+  describe 'GET /api/v1/providers' do
+    it 'returns providers' do
+      Provider.create!(valid_attributes)
+
+      get '/api/v1/providers'
+
+      expect(response).to have_http_status(:success)
+      json = JSON.parse(response.body)
+      expect(json.first['name']).to eq('Provider One')
+    end
+  end
+
+  describe 'GET /api/v1/providers/:id' do
+    it 'returns the provider' do
+      provider = Provider.create!(valid_attributes)
+
+      get "/api/v1/providers/#{provider.id}"
+
+      expect(response).to have_http_status(:success)
+      json = JSON.parse(response.body)
+      expect(json['id']).to eq(provider.id)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add request specs for authentication, categories, providers, and promotional banners
- add model validation specs for user, category, and provider

## Testing
- `bundle install` *(fails: Ruby version mismatch)*
- `bundle exec rspec spec/requests/api/v1/auth_spec.rb` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc0bd75488326b68fe2f250bb468e