### PR TITLE
Use shared API client and global error handling

### DIFF
--- a/src/hooks/useCompanyService.ts
+++ b/src/hooks/useCompanyService.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { api } from '@/services/api';
+import { api } from '@/middleware/authMiddleware';
 import { Company, CompanyFormData } from '@/types/company';
 
 export const useCompanyService = () => {

--- a/src/hooks/usePromoBanners.ts
+++ b/src/hooks/usePromoBanners.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import BannerService from '@/services/bannerService';
+import { api } from '@/middleware/authMiddleware';
 
 export interface PromoBanner {
   id: number;
@@ -44,13 +45,9 @@ export const usePromoBanners = (position?: string) => {
           throw new Error('VITE_API_URL não configurada');
         }
 
-        const response = await fetch(url);
+        const response = await api.get(url);
 
-        if (!response.ok) {
-          throw new Error('Falha ao carregar banners');
-        }
-
-        const data = await response.json();
+        const data = response.data;
         const mappedBanners = data.data.map((banner: any) => ({
           ...banner,
           background_image_url: banner.image_url,

--- a/src/middleware/authMiddleware.ts
+++ b/src/middleware/authMiddleware.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+import { toast } from 'sonner';
 
 interface ExtendedAxiosRequestConfig extends AxiosRequestConfig {
   _retry?: boolean;
@@ -103,6 +104,9 @@ class AuthMiddleware {
         if (error.response?.status === 401) {
           this.clearTokens();
           window.location.href = '/login';
+        } else {
+          const message = (error.response?.data as any)?.message || 'Ocorreu um erro inesperado.';
+          toast.error(message);
         }
         return Promise.reject(error);
       }


### PR DESCRIPTION
## Summary
- replace direct fetch calls with shared `api` axios instance
- add global error toast handling in auth middleware interceptors
- update hooks and services to import new api client

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc0eb810c8326b5cb66a3baa560f7