### PR TITLE
Add Rswag for API documentation

### DIFF
--- a/noticed_v2/Gemfile
+++ b/noticed_v2/Gemfile
@@ -100,11 +100,16 @@ gem 'redis'
 gem 'rails-i18n'
 gem 'country_select'
 
+gem 'rswag-api'
+gem 'rswag-ui'
+
 group :development, :test do
   # Testing framework
   gem 'rspec-rails'
   gem 'factory_bot_rails'
   gem 'faker'
+
+  gem 'rswag-specs'
   
   # Code quality
   gem 'rubocop', require: false

--- a/noticed_v2/config/routes.rb
+++ b/noticed_v2/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount Rswag::Ui::Engine => '/api-docs'
+  mount Rswag::Api::Engine => '/api-docs'
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
   get 'users/profile'

--- a/noticed_v2/spec/integration/categories_spec.rb
+++ b/noticed_v2/spec/integration/categories_spec.rb
@@ -1,0 +1,13 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/categories', type: :request do
+  path '/api/v1/categories' do
+    get('list categories') do
+      tags 'Categories'
+      produces 'application/json'
+      response(200, 'successful') do
+        run_test!
+      end
+    end
+  end
+end

--- a/noticed_v2/spec/swagger_helper.rb
+++ b/noticed_v2/spec/swagger_helper.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.configure do |config|
+  config.swagger_root = Rails.root.join('swagger').to_s
+
+  config.swagger_docs = {
+    'v1/swagger.yaml' => {
+      openapi: '3.0.1',
+      info: {
+        title: 'API V1',
+        version: 'v1'
+      },
+      paths: {},
+      servers: [
+        {
+          url: 'http://{defaultHost}',
+          variables: {
+            defaultHost: {
+              default: 'localhost:3000'
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  config.swagger_format = :yaml
+end

--- a/noticed_v2/swagger/v1/swagger.yaml
+++ b/noticed_v2/swagger/v1/swagger.yaml
@@ -1,0 +1,13 @@
+openapi: 3.0.1
+info:
+  title: API V1
+  version: v1
+paths:
+  /api/v1/categories:
+    get:
+      summary: list categories
+      tags:
+        - Categories
+      responses:
+        '200':
+          description: successful


### PR DESCRIPTION
## Summary
- add rswag gems for swagger-based API docs
- configure swagger helper and sample categories spec
- expose `/api-docs` via routes and check in generated Swagger file

## Testing
- `bundle install` *(fails: Your Ruby version is 3.4.4, but your Gemfile specified 3.2.2)*
- `bundle exec rake rswag:specs:swaggerize` *(fails: bundler setup error due to Ruby mismatch)*
- `bundle exec rspec` *(fails: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc2f4fccc8326874848e28dbd3fe5