### PR TITLE
Add CI workflow for backend and frontend with deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: noticed_v2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+      - name: Run RSpec
+        run: bundle exec rspec
+      - name: Compile assets
+        run: bundle exec rails assets:precompile
+      - name: Upload Rails assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: rails-assets
+          path: public/assets
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Test
+        run: npm run test
+      - name: Build
+        run: npm run build
+      - name: Upload Vite build
+        uses: actions/upload-artifact@v4
+        with:
+          name: vite-build
+          path: dist
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [backend, frontend]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy to Heroku
+        uses: akhileshns/heroku-deploy@v4.1.8
+        with:
+          heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
+          heroku_app_name: ${{ secrets.HEROKU_APP_NAME }}
+          heroku_email: ${{ secrets.HEROKU_EMAIL }}
+          appdir: noticed_v2
+      - name: Deploy to Vercel
+        uses: amondnet/vercel-action@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: .


### PR DESCRIPTION
## Summary
- add CI workflow running backend RSpec and frontend npm lint/test
- compile & upload Rails assets and Vite build artifacts
- deploy to Heroku and Vercel after successful tests

## Testing
- `npm run lint` *(fails: command not found: npm)*
- `apt-get update` *(fails: 403 Forbidden)*
- `bundle install` *(fails: Ruby version 3.4.4 vs required 3.2.2 and 403 fetching gems)*


------
https://chatgpt.com/codex/tasks/task_e_68bbc34efbf8832683039dc3a69e3c1c