### PR TITLE
Add rack-attack and secure headers setup

### DIFF
--- a/noticed_v2/Gemfile
+++ b/noticed_v2/Gemfile
@@ -6,6 +6,8 @@ ruby '3.2.2'
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem 'rails', '~> 7.0.6'
 gem 'rack-cors'
+gem 'rack-attack'
+gem 'secure_headers'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'

--- a/noticed_v2/config/initializers/rack_attack.rb
+++ b/noticed_v2/config/initializers/rack_attack.rb
@@ -1,0 +1,8 @@
+# Configure Rack::Attack for basic request throttling
+Rails.application.configure do
+  config.middleware.use Rack::Attack
+end
+
+Rack::Attack.throttle('req/ip', limit: 60, period: 1.minute) do |req|
+  req.ip
+end

--- a/noticed_v2/config/initializers/secure_headers.rb
+++ b/noticed_v2/config/initializers/secure_headers.rb
@@ -1,0 +1,7 @@
+# Set up basic security headers
+SecureHeaders::Configuration.default do |config|
+  config.csp = {
+    default_src: %w('self')
+  }
+  config.x_frame_options = 'DENY'
+end


### PR DESCRIPTION
## Summary
- Add `rack-attack` and `secure_headers` gems
- Configure throttling via Rack::Attack
- Add basic SecureHeaders configuration

## Testing
- `bundle install` *(fails: Your Ruby version is 3.4.4, but your Gemfile specified 3.2.2)*
- `bundle exec rspec` *(fails: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc2ed653c8326b6220100a5b40b3a